### PR TITLE
Allow Field to accept arbitrary kwargs

### DIFF
--- a/rest_framework/fields.py
+++ b/rest_framework/fields.py
@@ -160,7 +160,7 @@ class Field(object):
     def __init__(self, read_only=False, write_only=False,
                  required=None, default=empty, initial=empty, source=None,
                  label=None, help_text=None, style=None,
-                 error_messages=None, validators=None, allow_null=False):
+                 error_messages=None, validators=None, allow_null=False, **kwargs):
         self._creation_counter = Field._creation_counter
         Field._creation_counter += 1
 


### PR DESCRIPTION
This fixes an issue with arguments not expected when passing arguments from a Custom Paginator to the underlying object_serializer_class where the object_serializer_class is based upon ModelSerializer.